### PR TITLE
Mark Plug.Conn as halted for "GET /_ping"

### DIFF
--- a/lib/pinglix.ex
+++ b/lib/pinglix.ex
@@ -4,6 +4,7 @@ defmodule Pinglix do
       Module.register_attribute __MODULE__, :checks, accumulate: true
       import Pinglix
       import Plug.Conn
+      @dialyzer {:no_match, run_check: 1}
       @before_compile Pinglix
     end
   end

--- a/lib/pinglix.ex
+++ b/lib/pinglix.ex
@@ -22,6 +22,7 @@ defmodule Pinglix do
         conn
         |> put_resp_content_type("application/json", "UTF-8")
         |> send_resp(status.http_code, Poison.encode!(status))
+        |> halt()
       end
 
       def call(conn, _opts), do: conn

--- a/test/pinglix_test.exs
+++ b/test/pinglix_test.exs
@@ -27,6 +27,7 @@ defmodule PinglixTest do
   test "application responds to GET /_ping", %{conn: conn} do
     assert conn.state == :sent
     assert conn.status == 200
+    assert conn.halted
   end
 
   test "application uses correct content-type", %{conn: conn} do


### PR DESCRIPTION
This prevents futher plugs downstream from being invoked