### PR TITLE
Fix checker timeout incorrectly defaulting to 29ms instead of 29s

### DIFF
--- a/lib/pinglix.ex
+++ b/lib/pinglix.ex
@@ -15,7 +15,7 @@ defmodule Pinglix do
       end
 
       def call(conn = %Plug.Conn{path_info: ["_ping"], method: "GET"}, opts) do
-        opts = Keyword.merge([timeout: 29], opts)
+        opts = Keyword.merge([timeout: 29_000], opts)
         status = Pinglix.Checker.run(__MODULE__, @checks, opts[:timeout])
                  |> Pinglix.Status.set_current_time
 

--- a/lib/pinglix/checker.ex
+++ b/lib/pinglix/checker.ex
@@ -1,7 +1,7 @@
 defmodule Pinglix.Checker do
   alias Pinglix.Aggregator
 
-  def run(module, checks, timeout \\ 29000) do
+  def run(module, checks, timeout) do
     checks
     |> Enum.map(&Task.async(module, :run_check, [&1]))
     |> run_checks(Aggregator.new(checks), timeout)


### PR DESCRIPTION
## Context 
When a timeout option is not explicitly set for pinglix, it incorrectly defaults to 29ms instead of the documented 29s. 

## Summary of Changes
Remove the default argument for timeout from `Pinglix.Checker.run` and set the correct default timeout option in `call`